### PR TITLE
fix setting dest

### DIFF
--- a/cc-wrapper.sh
+++ b/cc-wrapper.sh
@@ -47,7 +47,7 @@ fi
 source="${sources[0]}"
 
 if [[ -z $dest ]]; then
-    dest="$(basename "$source" .c).o" # FIXME
+    dest="${source%.*}.o"
 fi
 
 if [[ $source =~ \.c$ ]]; then

--- a/cc-wrapper.sh
+++ b/cc-wrapper.sh
@@ -47,7 +47,7 @@ fi
 source="${sources[0]}"
 
 if [[ -z $dest ]]; then
-    dest="${source%.*}.o"
+    dest="$(basename "${source%.*}.o")"
 fi
 
 if [[ $source =~ \.c$ ]]; then


### PR DESCRIPTION
make it work with cpp source files

bash:

```sh
source=/a/b/c.x.y.cpp
dest="${source%.*}.o"
echo $dest
# /a/b/c.x.y.o
```

